### PR TITLE
feat: simplify with less alloc calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module ready-to-use-host-functions
 go 1.21.6
 
 require (
-	github.com/extism/go-pdk v1.0.1
+	github.com/extism/go-pdk v1.0.2-0.20240202061512-fae85da4456d
 	github.com/valyala/fastjson v1.6.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/extism/go-pdk v1.0.1 h1:M2L4sIgb2bUyEpmkpmwQu3H7ksd/EcDK44RaAd+YIeo=
 github.com/extism/go-pdk v1.0.1/go.mod h1:Gz+LIU/YCKnKXhgge8yo5Yu1F/lbv7KtKFkiCSzW/P4=
+github.com/extism/go-pdk v1.0.2-0.20240202061512-fae85da4456d h1:x3TtTceKEweMHjTSCfC7+7Z3F2mSMVX7ceSFBsfKrqE=
+github.com/extism/go-pdk v1.0.2-0.20240202061512-fae85da4456d/go.mod h1:Gz+LIU/YCKnKXhgge8yo5Yu1F/lbv7KtKFkiCSzW/P4=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/main.go
+++ b/main.go
@@ -1,37 +1,34 @@
 package main
 
 import (
-    "github.com/extism/go-pdk"
+	"github.com/extism/go-pdk"
 )
 
 //export fetch_url_content
 func fetch_url_content() int32 {
-    // Read function argument from memory, which is the URL
-    input := string(pdk.Input())
+	// Read function argument from memory, which is the URL
+	input := string(pdk.Input())
 
-    // Write information to the logs indicating the URL being fetched
-    pdk.Log(pdk.LogInfo, "Fetching URL: "+input)
+	// Write information to the logs indicating the URL being fetched
+	pdk.Log(pdk.LogInfo, "Fetching URL: "+input)
 
-    // Make an HTTP GET request to the URL
-    req := pdk.NewHTTPRequest(pdk.MethodGet, input)
-    res := req.Send()
+	// Make an HTTP GET request to the URL
+	req := pdk.NewHTTPRequest(pdk.MethodGet, input)
+	res := req.Send()
 
-    // Check if the request was successful by examining if the body is not empty
-    if len(res.Body()) == 0 {
-        errMsg := "Failed to fetch URL"
-        pdk.Log(pdk.LogError, errMsg)
-        mem := pdk.AllocateString(errMsg)
-        pdk.OutputMemory(mem)
-        return 1 // Indicate an error occurred
-    }
+	// Check if the request was successful by examining if the body is not empty
+	if len(res.Body()) == 0 {
+		errMsg := "Failed to fetch URL"
+		pdk.Log(pdk.LogError, errMsg)
+		mem := pdk.AllocateString(errMsg)
+		pdk.OutputMemory(mem)
+		return 1 // Indicate an error occurred
+	}
 
-    // Assuming the request was successful, return the body (HTML content)
-    htmlContent := string(res.Body())
-    mem := pdk.AllocateString(htmlContent)
-    pdk.OutputMemory(mem)
+	// Assuming the request was successful, return the body (HTML content)
+	pdk.OutputMemory(res.Memory())
 
-    return 0 // Success
+	return 0 // Success
 }
 
 func main() {}
-


### PR DESCRIPTION
Updates to the latest version of the PDK, and simplifies the output of the plugin:

```patch
// Assuming the request was successful, return the body (HTML content)
- htmlContent := string(res.Body())
- mem := pdk.AllocateString(htmlContent)
- pdk.OutputMemory(mem)
+ pdk.OutputMemory(res.Memory())
```

Just for some additional info:

```go
htmlContent := string(res.Body())
mem := pdk.AllocateString(htmlContent)
```

these lines allocate twice. once to copy & encode the bytes from the HTTP body to a string, and another with the pdk.AllocateString call. 

using 
```go
pdk.OutputMemory(res.Memory()) 
```

instead, shares the allocation from the original request. if you dont need to transform the HTTP body at all, this can save quite a bit.